### PR TITLE
Define _POSIX_C_SOURCE to get access to strdup() and strndup().

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -23,6 +23,7 @@
 
 #include "parson.h"
 
+#define _POSIX_C_SOURCE      200809L /* for strdup()/strndup() */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
`strdup` and `strndup` are only available in C libraries with `_GNU_SOURCE`, `_BSD_SOURCE`, `_POSIX_C_SOURCE>=200809L` or `_XOPEN_SOURCE=700`.

Since `_GNU_SOURCE` and `_BSD_SOURCE` are vendor specific and `_XOPEN_SOURCE=700` represents POSIX.2008 plus extensions, defining `_POSIX_C_SOURCE` to `200809L` is the most portable way to access `strdup` and `strndup`.
